### PR TITLE
- fix devName0/devName1/devName2 array overflow.

### DIFF
--- a/CoDrone.h
+++ b/CoDrone.h
@@ -754,9 +754,9 @@ public:
 	int devRSSI1 = -1;
 	int devRSSI2 = -1;
 		
-	byte devName0[20];
-	byte devName1[20];
-	byte devName2[20];
+	byte devName0[26];
+	byte devName1[26];
+	byte devName2[26];
 		
 	byte devAddress0[6];
 	byte devAddress1[6];


### PR DESCRIPTION
After discovering device, the device names are saved to devName0/1/2 array. 
But the array size is small so it could access wrong address.
I know it's ok if the name is short.

 for (int i = 9; i <= 28; i++)
 {
        devName1[i - 3] = dataBuff[i];
 }
