### PR TITLE
Use a single tab field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -6,72 +6,72 @@
 # Datatypes (KEYWORD1)
 #######################################
 
-CoDrone				KEYWORD1
-gyrodata			KEYWORD1
-acceldata			KEYWORD1
-angledata			KEYWORD1
-trimdata			KEYWORD1
-optdata				KEYWORD1
+CoDrone	KEYWORD1
+gyrodata	KEYWORD1
+acceldata	KEYWORD1
+angledata	KEYWORD1
+trimdata	KEYWORD1
+optdata	KEYWORD1
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
 
-begin				KEYWORD2
-print				KEYWORD2
-write				KEYWORD2
+begin	KEYWORD2
+print	KEYWORD2
+write	KEYWORD2
+a
+Control	KEYWORD2
 
-Control				KEYWORD2
+LedColor	KEYWORD2
+LedEvent	KEYWORD2
+LedColorDefault	KEYWORD2
 
-LedColor			KEYWORD2
-LedEvent			KEYWORD2
-LedColorDefault			KEYWORD2
-
-FlightEvent			KEYWORD2
-DriveEvent			KEYWORD2
-Receive				KEYWORD2
-AutoConnect			KEYWORD2
-BattleHitPoints			KEYWORD2
-CrashedCheck 			KEYWORD2
-CrashCustom			KEYWORD2
-AnalogScaleChange 	KEYWORD2
-Buzz				KEYWORD2
+FlightEvent	KEYWORD2
+DriveEvent	KEYWORD2
+Receive	KEYWORD2
+AutoConnect	KEYWORD2
+BattleHitPoints	KEYWORD2
+CrashedCheck	KEYWORD2
+CrashCustom	KEYWORD2
+AnalogScaleChange	KEYWORD2
+Buzz	KEYWORD2
 
 Request_DroneState	KEYWORD2
 Request_DroneAttitude	KEYWORD2
 Request_DroneGyroBias	KEYWORD2
-Request_TrimAll 	KEYWORD2
+Request_TrimAll	KEYWORD2
 Request_TrimFlight	KEYWORD2
 Request_TrimDrive	KEYWORD2
 Request_ImuRawAndAngle	KEYWORD2
 Request_Pressure	KEYWORD2
 Request_ImageFlow	KEYWORD2
-Request_Button		KEYWORD2
-Request_Battery		KEYWORD2
-Request_Motor		KEYWORD2
+Request_Button	KEYWORD2
+Request_Battery	KEYWORD2
+Request_Motor	KEYWORD2
 Request_Temprature	KEYWORD2
-Request_Range 		KEYWORD2
+Request_Range	KEYWORD2
 
 Send_ResetHeading	KEYWORD2
 
-PrintGyro			KEYWORD2
+PrintGyro	KEYWORD2
 
-PrintDroneAddress	KEYWORD2	
-LowBatteryCheck		KEYWORD2	
-DroneModeChange		KEYWORD2	
+PrintDroneAddress	KEYWORD2
+LowBatteryCheck	KEYWORD2
+DroneModeChange	KEYWORD2
 
-BattleBegin			KEYWORD2
-BattleReceive		KEYWORD2
-BattleShooting		KEYWORD2
+BattleBegin	KEYWORD2
+BattleReceive	KEYWORD2
+BattleShooting	KEYWORD2
 
 ButtonPreesHoldWait	KEYWORD2
 
-Set_Trim			KEYWORD2
-Set_TrimAll			KEYWORD2
-Set_TrimReset		KEYWORD2
+Set_Trim	KEYWORD2
+Set_TrimAll	KEYWORD2
+Set_TrimReset	KEYWORD2
 
-LED_Blink			KEYWORD2
-LED_Connect			KEYWORD2
+LED_Blink	KEYWORD2
+LED_Connect	KEYWORD2
 
 
 
@@ -79,98 +79,98 @@ LED_Connect			KEYWORD2
 # Constants (LITERAL1)
 #######################################
 
-gyroAngle			LITERAL1
+gyroAngle	LITERAL1
 
-Flight				LITERAL1
-FlightNoGuard		LITERAL1
-FlightFPV			LITERAL1
-Drive				LITERAL1
-DriveFPV			LITERAL1
+Flight	LITERAL1
+FlightNoGuard	LITERAL1
+FlightFPV	LITERAL1
+Drive	LITERAL1
+DriveFPV	LITERAL1
 
-ROLL				LITERAL1
-PITCH				LITERAL1
-YAW					LITERAL1
-THROTTLE			LITERAL1
-NearbyDrone			LITERAL1
-ConnectedDrone		LITERAL1
+ROLL	LITERAL1
+PITCH	LITERAL1
+YAW	LITERAL1
+THROTTLE	LITERAL1
+NearbyDrone	LITERAL1
+ConnectedDrone	LITERAL1
 AddressInputDrone	LITERAL1
-Nearest				LITERAL1
+Nearest	LITERAL1
 
 
-PAIRING				LITERAL1
-DiscoverStart		LITERAL1
-DiscoverStop		LITERAL1
+PAIRING	LITERAL1
+DiscoverStart	LITERAL1
+DiscoverStop	LITERAL1
 
-Stop				LITERAL1
+Stop	LITERAL1
 
-EVENT				LITERAL1
-STATE				LITERAL1
-SEND_INTERVAL		LITERAL1
-CONNECTION			LITERAL1
-ANALOG_OFFSET		LITERAL1
-		
-TakeOff				LITERAL1
-Landing				LITERAL1
+EVENT	LITERAL1
+STATE	LITERAL1
+SEND_INTERVAL	LITERAL1
+CONNECTION	LITERAL1
+ANALOG_OFFSET	LITERAL1
+
+TakeOff	LITERAL1
+Landing	LITERAL1
 
 
-EyeNone				LITERAL1
-EyeHold				LITERAL1
-EyeMix				LITERAL1
-EyeFlicker			LITERAL1
+EyeNone	LITERAL1
+EyeHold	LITERAL1
+EyeMix	LITERAL1
+EyeFlicker	LITERAL1
 EyeFlickerDouble	LITERAL1
-EyeDimming			LITERAL1
+EyeDimming	LITERAL1
 
-ArmNone				LITERAL1
-ArmHold				LITERAL1
-ArmMix				LITERAL1
-ArmFlicker			LITERAL1
+ArmNone	LITERAL1
+ArmHold	LITERAL1
+ArmMix	LITERAL1
+ArmFlicker	LITERAL1
 ArmFlickerDouble	LITERAL1
-ArmDimming			LITERAL1
-ArmFlow				LITERAL1
-ArmFlowReverse		LITERAL1
+ArmDimming	LITERAL1
+ArmFlow	LITERAL1
+ArmFlowReverse	LITERAL1
 
 
-RollIncrease		LITERAL1
-RollDecrease		LITERAL1
-PitchIncrease		LITERAL1
-PitchDecrease		LITERAL1
-YawIncrease			LITERAL1
-YawDecrease			LITERAL1
+RollIncrease	LITERAL1
+RollDecrease	LITERAL1
+PitchIncrease	LITERAL1
+PitchDecrease	LITERAL1
+YawIncrease	LITERAL1
+YawDecrease	LITERAL1
 ThrottleIncrease	LITERAL1
 ThrottleDecrease	LITERAL1
 
-TEAM_RED			LITERAL1
-TEAM_BLUE			LITERAL1
-TEAM_GREEN			LITERAL1
-TEAM_YELLOW			LITERAL1
-FREE_PLAY			LITERAL1
+TEAM_RED	LITERAL1
+TEAM_BLUE	LITERAL1
+TEAM_GREEN	LITERAL1
+TEAM_YELLOW	LITERAL1
+FREE_PLAY	LITERAL1
 
-energy				LITERAL1
+energy	LITERAL1
 
-LEFT				LITERAL1
-FORWARD				LITERAL1
-RIGHT				LITERAL1
-BACKWARD			LITERAL1
-UP					LITERAL1
-DOWN				LITERAL1
+LEFT	LITERAL1
+FORWARD	LITERAL1
+RIGHT	LITERAL1
+BACKWARD	LITERAL1
+UP	LITERAL1
+DOWN	LITERAL1
 
-ZIGZAG				LITERAL1
-SWAY				LITERAL1
-SQUARE				LITERAL1
-CIRCLE				LITERAL1
-SPIRAL				LITERAL1
-TRIANGLE			LITERAL1
-HOP					LITERAL1
+ZIGZAG	LITERAL1
+SWAY	LITERAL1
+SQUARE	LITERAL1
+CIRCLE	LITERAL1
+SPIRAL	LITERAL1
+TRIANGLE	LITERAL1
+HOP	LITERAL1
 
-LED_None 			LITERAL1
-LED_Hold			LITERAL1
-LED_Mix				LITERAL1
-LED_Flicker			LITERAL1
+LED_None	LITERAL1
+LED_Hold	LITERAL1
+LED_Mix	LITERAL1
+LED_Flicker	LITERAL1
 LED_FlickerDouble	LITERAL1
-LED_Dimming			LITERAL1
-LED_Flow			LITERAL1
-LED_FlowReverse		LITERAL1
-LED_EndOfType		LITERAL1
+LED_Dimming	LITERAL1
+LED_Flow	LITERAL1
+LED_FlowReverse	LITERAL1
+LED_EndOfType	LITERAL1
 
 
 


### PR DESCRIPTION
Each field of keywords.txt is separated by a single true tab. When you use multiple tabs it causes the field to be interpreted as empty. On Arduino IDE 1.6.5 and newer an empty KEYWORD_TOKENTYPE causes the default editor.function.style coloration to be used (as with KEYWORD2, KEYWORD3, LITERAL2). On Arduino IDE 1.6.4 and older it causes the keyword to not be recognized for any special coloration.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords