### PR TITLE
Add missing loop() to example sketch

### DIFF
--- a/examples/Legacy Examples/Receive/RSSI_Polling/Rssi_Polling.ino
+++ b/examples/Legacy Examples/Receive/RSSI_Polling/Rssi_Polling.ino
@@ -12,7 +12,6 @@ void setup()
   CoDrone.DisplayRSSI();            //Show RSSI power using smartboard LEDs
 }
 
-
-
-
-
+void loop()
+{
+}


### PR DESCRIPTION
Without the loop function, compilation fails:
```
main.cpp:46: undefined reference to `loop'
```